### PR TITLE
feat: [TASK-02] Types TypeScript partagés (words)

### DIFF
--- a/shared/__tests__/themes.test.ts
+++ b/shared/__tests__/themes.test.ts
@@ -1,0 +1,24 @@
+import { isValidTheme, THEMES } from '../constants/themes'
+
+describe('isValidTheme', () => {
+  it('retourne true pour chaque thème valide', () => {
+    for (const theme of THEMES) {
+      expect(isValidTheme(theme)).toBe(true)
+    }
+  })
+
+  it('retourne false pour une chaîne invalide', () => {
+    expect(isValidTheme('inconnu')).toBe(false)
+    expect(isValidTheme('')).toBe(false)
+    expect(isValidTheme('CLASSIQUE')).toBe(false)
+  })
+
+  it('retourne false pour des types non-string', () => {
+    expect(isValidTheme(null)).toBe(false)
+    expect(isValidTheme(undefined)).toBe(false)
+    expect(isValidTheme(42)).toBe(false)
+    expect(isValidTheme(true)).toBe(false)
+    expect(isValidTheme({})).toBe(false)
+    expect(isValidTheme([])).toBe(false)
+  })
+})

--- a/shared/constants/themes.ts
+++ b/shared/constants/themes.ts
@@ -1,0 +1,12 @@
+import type { Theme } from '../types/words'
+
+export const THEMES: readonly Theme[] = [
+  'classique',
+  'anime',
+  'pop-culture',
+  'musique',
+] as const
+
+export function isValidTheme(value: unknown): value is Theme {
+  return typeof value === 'string' && (THEMES as readonly string[]).includes(value)
+}

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -1,0 +1,3 @@
+export * from './types/words'
+export * from './types/game'
+export * from './constants/themes'

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@underword/shared",
+  "version": "0.1.0",
+  "private": true,
+  "main": "./index.ts",
+  "types": "./index.ts"
+}

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "outDir": "./dist",
+    "rootDir": ".",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["types/**/*", "constants/**/*"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}

--- a/shared/types/game.ts
+++ b/shared/types/game.ts
@@ -1,0 +1,19 @@
+import type { Theme } from './words'
+
+export type { Theme }
+
+export type Role = 'civil' | 'imposteur' | 'mister-white'
+
+export interface Player {
+  id: string
+  name: string
+  role?: Role
+  isEliminated: boolean
+}
+
+export interface GameConfig {
+  playerNames: string[]
+  theme: Theme
+  impostorCount: number | 'auto'
+  misterWhiteEnabled: boolean
+}

--- a/shared/types/words.ts
+++ b/shared/types/words.ts
@@ -1,0 +1,40 @@
+export type Theme = 'classique' | 'anime' | 'pop-culture' | 'musique'
+
+export interface WordPair {
+  id: string
+  theme: Theme
+  civilWord: string
+  impostorWord: string
+  isActive: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface WordPairSelection {
+  civilWord: string
+  impostorWord: string
+}
+
+export interface CreateWordPairPayload {
+  theme: Theme
+  civilWord: string
+  impostorWord: string
+}
+
+export type UpdateWordPairPayload = Partial<
+  Pick<CreateWordPairPayload, 'civilWord' | 'impostorWord'> & {
+    theme: Theme
+    isActive: boolean
+  }
+>
+
+export interface WordPairListResponse {
+  data: WordPair[]
+  total: number
+  page: number
+  pageSize: number
+}
+
+export interface WordPairDrawResponse {
+  pair: WordPairSelection
+}


### PR DESCRIPTION
Closes #31

## Ce qui a été fait

- `shared/types/words.ts` — `Theme`, `WordPair`, `WordPairSelection`, `CreateWordPairPayload`, `UpdateWordPairPayload`, `WordPairListResponse`, `WordPairDrawResponse`
- `shared/constants/themes.ts` — tableau `THEMES` (readonly) + type guard `isValidTheme()`
- `shared/types/game.ts` — importe `Theme` depuis `words.ts` et le ré-exporte (pas de duplication)
- `shared/tsconfig.json` — TypeScript strict, commonjs, target ES2022

## Points notables

- `Theme` défini une seule fois dans `words.ts`
- Le ré-export `export type { Theme }` dans `game.ts` préserve la rétrocompatibilité
- Le cast `as readonly string[]` dans `isValidTheme` est le seul workaround justifié (limitation de `Array.includes` en mode strict)

## Prérequis de vérification

Node.js n'est pas encore installé sur la machine de développement. La vérification `tsc --noEmit` devra être faite après installation de Node.js + `npm install` dans `shared/`.

## Dépendances aval

- TASK-03 (#32) — modèle wordPair (importe les types)
- TASK-05 (#34) — middleware Zod (importe Theme pour la validation)