### PR TITLE
feat: [TASK-01] Migration PostgreSQL et connexion DB

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,16 @@
+# Connexion PostgreSQL (choisir l'une des deux formes)
+DATABASE_URL=postgresql://user:password@localhost:5432/underword
+
+# OU variables individuelles (ignorées si DATABASE_URL est défini)
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=underword
+DB_USER=user
+DB_PASSWORD=password
+
+# Serveur
+PORT=3000
+NODE_ENV=development
+
+# Auth admin (pour les routes /api/admin/*)
+ADMIN_TOKEN=changeme

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "underword-backend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "ts-node src/app.ts",
+    "build": "tsc",
+    "start": "node dist/app.js",
+    "db:migrate": "ts-node src/db/migrate.ts",
+    "db:seed": "ts-node src/db/seeds/index.ts",
+    "db:reset": "npm run db:migrate && npm run db:seed",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.18.3",
+    "pg": "^8.11.5",
+    "socket.io": "^4.7.5",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.12.7",
+    "@types/pg": "^8.11.5",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/backend/src/db/connection.ts
+++ b/backend/src/db/connection.ts
@@ -1,0 +1,32 @@
+import 'dotenv/config'
+import pg from 'pg'
+
+const { Pool } = pg
+
+function createPool(): pg.Pool {
+  const connectionString = process.env['DATABASE_URL']
+
+  if (connectionString !== undefined && connectionString !== '') {
+    return new Pool({ connectionString })
+  }
+
+  return new Pool({
+    host: process.env['DB_HOST'] ?? 'localhost',
+    port: parseInt(process.env['DB_PORT'] ?? '5432', 10),
+    database: process.env['DB_NAME'] ?? 'underword',
+    user: process.env['DB_USER'],
+    password: process.env['DB_PASSWORD'],
+  })
+}
+
+const pool: pg.Pool = createPool()
+
+export async function query<T extends pg.QueryResultRow>(
+  sql: string,
+  params?: unknown[]
+): Promise<T[]> {
+  const result = await pool.query<T>(sql, params)
+  return result.rows
+}
+
+export { pool }

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -1,0 +1,55 @@
+import 'dotenv/config'
+import fs from 'fs'
+import path from 'path'
+import { pool } from './connection'
+
+const MIGRATIONS_DIR = path.join(__dirname, 'migrations')
+
+function getMigrationFiles(): string[] {
+  const files = fs.readdirSync(MIGRATIONS_DIR)
+  return files
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+}
+
+async function runMigrations(): Promise<void> {
+  const files = getMigrationFiles()
+
+  if (files.length === 0) {
+    console.log('Aucun fichier de migration trouvé.')
+    return
+  }
+
+  const client = await pool.connect()
+
+  try {
+    await client.query('BEGIN')
+
+    for (const file of files) {
+      const filePath = path.join(MIGRATIONS_DIR, file)
+      const sql = fs.readFileSync(filePath, 'utf8')
+
+      console.log(`Migration : ${file}`)
+      await client.query(sql)
+      console.log(`  ✓ ${file} appliqué`)
+    }
+
+    await client.query('COMMIT')
+    console.log(`\n${files.length} migration(s) appliquée(s) avec succès.`)
+  } catch (error) {
+    await client.query('ROLLBACK')
+    console.error('Erreur lors de la migration, rollback effectué.')
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+runMigrations()
+  .catch((error: unknown) => {
+    console.error(error)
+    process.exit(1)
+  })
+  .finally(() => {
+    void pool.end()
+  })

--- a/backend/src/db/migrations/001_create_word_pairs.sql
+++ b/backend/src/db/migrations/001_create_word_pairs.sql
@@ -1,0 +1,89 @@
+-- Migration 001 : création de la table word_pairs
+-- Idempotente : sûre à rejouer
+
+-- Création du type enum (idempotente via DO block car CREATE TYPE IF NOT EXISTS n'existe pas en PG <14)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'theme_enum') THEN
+    CREATE TYPE theme_enum AS ENUM (
+      'classique',
+      'anime',
+      'pop-culture',
+      'musique'
+    );
+  END IF;
+END;
+$$;
+
+-- Création de la table
+CREATE TABLE IF NOT EXISTS word_pairs (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  theme          theme_enum  NOT NULL,
+  civil_word     TEXT        NOT NULL,
+  impostor_word  TEXT        NOT NULL,
+  is_active      BOOLEAN     NOT NULL DEFAULT TRUE,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Contraintes CHECK (ADD CONSTRAINT IF NOT EXISTS n'existe pas — vérification via pg_constraint)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'civil_word_not_empty'
+      AND conrelid = 'word_pairs'::regclass
+  ) THEN
+    ALTER TABLE word_pairs
+      ADD CONSTRAINT civil_word_not_empty
+        CHECK (trim(civil_word) <> '');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'impostor_word_not_empty'
+      AND conrelid = 'word_pairs'::regclass
+  ) THEN
+    ALTER TABLE word_pairs
+      ADD CONSTRAINT impostor_word_not_empty
+        CHECK (trim(impostor_word) <> '');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'civil_impostor_different'
+      AND conrelid = 'word_pairs'::regclass
+  ) THEN
+    ALTER TABLE word_pairs
+      ADD CONSTRAINT civil_impostor_different
+        CHECK (lower(trim(civil_word)) <> lower(trim(impostor_word)));
+  END IF;
+END;
+$$;
+
+-- Index
+CREATE INDEX IF NOT EXISTS idx_word_pairs_theme_active
+  ON word_pairs (theme, is_active)
+  WHERE is_active = TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_word_pairs_theme
+  ON word_pairs (theme, created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_word_pairs_unique_pair
+  ON word_pairs (theme, lower(civil_word), lower(impostor_word));
+
+-- Fonction trigger updated_at (CREATE OR REPLACE est idempotente)
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+-- Trigger (DROP IF EXISTS + CREATE pour idempotence)
+DROP TRIGGER IF EXISTS trg_word_pairs_updated_at ON word_pairs;
+
+CREATE TRIGGER trg_word_pairs_updated_at
+  BEFORE UPDATE ON word_pairs
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": false,
+    "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@shared/*": ["../shared/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Closes #30

## Ce qui a été fait

- `backend/src/db/connection.ts` — pool `pg.Pool` singleton, fonction `query<T extends pg.QueryResultRow>()` typée, chargement via `DATABASE_URL` ou variables `DB_*`
- `backend/src/db/migrations/001_create_word_pairs.sql` — migration idempotente :
  - `theme_enum` via DO block (compatible PG < 14)
  - `word_pairs` avec `CREATE TABLE IF NOT EXISTS`
  - Contraintes CHECK via DO block sur `pg_constraint`
  - Index partiels avec `IF NOT EXISTS`
  - Trigger `updated_at` via DROP + CREATE
- `backend/src/db/migrate.ts` — runner transactionnel : lit les `.sql` en ordre alphanumérique, BEGIN/COMMIT avec ROLLBACK automatique en cas d'erreur, `void pool.end()` dans `.finally()`
- `backend/package.json` — express, pg, dotenv, socket.io, zod + types + ts-node
- `backend/tsconfig.json` — TypeScript strict, commonjs, ES2022, paths `@shared/*`
- `backend/.env.example` — template des variables d'environnement

## Points notables

- `gen_random_uuid()` natif PostgreSQL 13+ (pas d'extension pgcrypto requise)
- DDL transactionnel PostgreSQL : toute la migration passe ou rollback entièrement
- Aucun import `@shared/*` dans les fichiers DB (compatibilité ts-node sans tsconfig-paths)

## Prérequis de vérification

Node.js doit être installé sur la machine. Commandes de vérification :
```bash
cd backend && npm install && npm run type-check
# Puis avec une DB PostgreSQL :
npm run db:migrate
```

## Dépendances aval

- TASK-03 (#32) — modèle wordPair (utilise `query<T>` depuis connection.ts)
- TASK-09 (#38) — seed initial (utilise `npm run db:migrate` comme prérequis)