### PR TITLE
feat: [TASK-03] Modèle de données wordPair

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,16 @@
+# Connexion PostgreSQL (choisir l'une des deux formes)
+DATABASE_URL=postgresql://user:password@localhost:5432/underword
+
+# OU variables individuelles (ignorées si DATABASE_URL est défini)
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=underword
+DB_USER=user
+DB_PASSWORD=password
+
+# Serveur
+PORT=3000
+NODE_ENV=development
+
+# Auth admin (pour les routes /api/admin/*)
+ADMIN_TOKEN=changeme

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "underword-backend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "ts-node src/app.ts",
+    "build": "tsc",
+    "start": "node dist/app.js",
+    "db:migrate": "ts-node src/db/migrate.ts",
+    "db:seed": "ts-node src/db/seeds/index.ts",
+    "db:reset": "npm run db:migrate && npm run db:seed",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.18.3",
+    "pg": "^8.11.5",
+    "socket.io": "^4.7.5",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.12.7",
+    "@types/pg": "^8.11.5",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/backend/src/db/connection.ts
+++ b/backend/src/db/connection.ts
@@ -1,0 +1,32 @@
+import 'dotenv/config'
+import pg from 'pg'
+
+const { Pool } = pg
+
+function createPool(): pg.Pool {
+  const connectionString = process.env['DATABASE_URL']
+
+  if (connectionString !== undefined && connectionString !== '') {
+    return new Pool({ connectionString })
+  }
+
+  return new Pool({
+    host: process.env['DB_HOST'] ?? 'localhost',
+    port: parseInt(process.env['DB_PORT'] ?? '5432', 10),
+    database: process.env['DB_NAME'] ?? 'underword',
+    user: process.env['DB_USER'],
+    password: process.env['DB_PASSWORD'],
+  })
+}
+
+const pool: pg.Pool = createPool()
+
+export async function query<T extends pg.QueryResultRow>(
+  sql: string,
+  params?: unknown[]
+): Promise<T[]> {
+  const result = await pool.query<T>(sql, params)
+  return result.rows
+}
+
+export { pool }

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -1,0 +1,55 @@
+import 'dotenv/config'
+import fs from 'fs'
+import path from 'path'
+import { pool } from './connection'
+
+const MIGRATIONS_DIR = path.join(__dirname, 'migrations')
+
+function getMigrationFiles(): string[] {
+  const files = fs.readdirSync(MIGRATIONS_DIR)
+  return files
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+}
+
+async function runMigrations(): Promise<void> {
+  const files = getMigrationFiles()
+
+  if (files.length === 0) {
+    console.log('Aucun fichier de migration trouvé.')
+    return
+  }
+
+  const client = await pool.connect()
+
+  try {
+    await client.query('BEGIN')
+
+    for (const file of files) {
+      const filePath = path.join(MIGRATIONS_DIR, file)
+      const sql = fs.readFileSync(filePath, 'utf8')
+
+      console.log(`Migration : ${file}`)
+      await client.query(sql)
+      console.log(`  ✓ ${file} appliqué`)
+    }
+
+    await client.query('COMMIT')
+    console.log(`\n${files.length} migration(s) appliquée(s) avec succès.`)
+  } catch (error) {
+    await client.query('ROLLBACK')
+    console.error('Erreur lors de la migration, rollback effectué.')
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+runMigrations()
+  .catch((error: unknown) => {
+    console.error(error)
+    process.exit(1)
+  })
+  .finally(() => {
+    void pool.end()
+  })

--- a/backend/src/db/migrations/001_create_word_pairs.sql
+++ b/backend/src/db/migrations/001_create_word_pairs.sql
@@ -1,0 +1,89 @@
+-- Migration 001 : création de la table word_pairs
+-- Idempotente : sûre à rejouer
+
+-- Création du type enum (idempotente via DO block car CREATE TYPE IF NOT EXISTS n'existe pas en PG <14)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'theme_enum') THEN
+    CREATE TYPE theme_enum AS ENUM (
+      'classique',
+      'anime',
+      'pop-culture',
+      'musique'
+    );
+  END IF;
+END;
+$$;
+
+-- Création de la table
+CREATE TABLE IF NOT EXISTS word_pairs (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  theme          theme_enum  NOT NULL,
+  civil_word     TEXT        NOT NULL,
+  impostor_word  TEXT        NOT NULL,
+  is_active      BOOLEAN     NOT NULL DEFAULT TRUE,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Contraintes CHECK (ADD CONSTRAINT IF NOT EXISTS n'existe pas — vérification via pg_constraint)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'civil_word_not_empty'
+      AND conrelid = 'word_pairs'::regclass
+  ) THEN
+    ALTER TABLE word_pairs
+      ADD CONSTRAINT civil_word_not_empty
+        CHECK (trim(civil_word) <> '');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'impostor_word_not_empty'
+      AND conrelid = 'word_pairs'::regclass
+  ) THEN
+    ALTER TABLE word_pairs
+      ADD CONSTRAINT impostor_word_not_empty
+        CHECK (trim(impostor_word) <> '');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'civil_impostor_different'
+      AND conrelid = 'word_pairs'::regclass
+  ) THEN
+    ALTER TABLE word_pairs
+      ADD CONSTRAINT civil_impostor_different
+        CHECK (lower(trim(civil_word)) <> lower(trim(impostor_word)));
+  END IF;
+END;
+$$;
+
+-- Index
+CREATE INDEX IF NOT EXISTS idx_word_pairs_theme_active
+  ON word_pairs (theme, is_active)
+  WHERE is_active = TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_word_pairs_theme
+  ON word_pairs (theme, created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_word_pairs_unique_pair
+  ON word_pairs (theme, lower(civil_word), lower(impostor_word));
+
+-- Fonction trigger updated_at (CREATE OR REPLACE est idempotente)
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+-- Trigger (DROP IF EXISTS + CREATE pour idempotence)
+DROP TRIGGER IF EXISTS trg_word_pairs_updated_at ON word_pairs;
+
+CREATE TRIGGER trg_word_pairs_updated_at
+  BEFORE UPDATE ON word_pairs
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/backend/src/models/wordPair.ts
+++ b/backend/src/models/wordPair.ts
@@ -1,0 +1,136 @@
+import { query } from '../db/connection'
+import type {
+  Theme,
+  WordPair,
+  WordPairSelection,
+  CreateWordPairPayload,
+  UpdateWordPairPayload,
+} from '../../shared/types/words'
+
+interface WordPairRow {
+  id: string
+  theme: Theme
+  civil_word: string
+  impostor_word: string
+  is_active: boolean
+  created_at: Date
+  updated_at: Date
+}
+
+export interface PairFilters {
+  theme?: Theme
+  page?: number
+  pageSize?: number
+  activeOnly?: boolean
+}
+
+function mapRow(row: WordPairRow): WordPair {
+  return {
+    id: row.id,
+    theme: row.theme,
+    civilWord: row.civil_word,
+    impostorWord: row.impostor_word,
+    isActive: row.is_active,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  }
+}
+
+// ORDER BY RANDOM() fait un seq scan sur les paires filtrées.
+// Acceptable pour le volume attendu (quelques centaines de paires par thème).
+export async function findRandomPairByTheme(theme: Theme): Promise<WordPairSelection | null> {
+  const rows = await query<WordPairRow>(
+    `SELECT civil_word, impostor_word
+     FROM word_pairs
+     WHERE theme = $1 AND is_active = TRUE
+     ORDER BY RANDOM()
+     LIMIT 1`,
+    [theme]
+  )
+  if (rows.length === 0) return null
+  const row = rows[0]
+  return { civilWord: row.civil_word, impostorWord: row.impostor_word }
+}
+
+export async function findAllPairs(
+  filters: PairFilters
+): Promise<{ rows: WordPair[]; total: number }> {
+  const { theme, page = 1, pageSize = 20, activeOnly = false } = filters
+  const conditions: string[] = []
+  const params: unknown[] = []
+  let idx = 1
+
+  if (theme !== undefined) {
+    conditions.push(`theme = $${idx}`)
+    params.push(theme)
+    idx++
+  }
+  if (activeOnly) {
+    conditions.push('is_active = TRUE')
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+
+  const countRows = await query<{ count: string }>(
+    `SELECT COUNT(*) AS count FROM word_pairs ${where}`,
+    params
+  )
+  const total = parseInt(countRows[0]?.count ?? '0', 10)
+
+  const offset = (page - 1) * pageSize
+  const dataRows = await query<WordPairRow>(
+    `SELECT * FROM word_pairs ${where} ORDER BY created_at DESC LIMIT $${idx} OFFSET $${idx + 1}`,
+    [...params, pageSize, offset]
+  )
+
+  return { rows: dataRows.map(mapRow), total }
+}
+
+export async function findPairById(id: string): Promise<WordPair | null> {
+  const rows = await query<WordPairRow>(
+    'SELECT * FROM word_pairs WHERE id = $1',
+    [id]
+  )
+  return rows.length > 0 ? mapRow(rows[0]) : null
+}
+
+export async function createPair(payload: CreateWordPairPayload): Promise<WordPair> {
+  const rows = await query<WordPairRow>(
+    `INSERT INTO word_pairs (theme, civil_word, impostor_word)
+     VALUES ($1, $2, $3)
+     RETURNING *`,
+    [payload.theme, payload.civilWord, payload.impostorWord]
+  )
+  return mapRow(rows[0])
+}
+
+export async function updatePair(
+  id: string,
+  payload: UpdateWordPairPayload
+): Promise<WordPair | null> {
+  const fields: Array<[string, unknown]> = []
+
+  if (payload.civilWord !== undefined) fields.push(['civil_word', payload.civilWord])
+  if (payload.impostorWord !== undefined) fields.push(['impostor_word', payload.impostorWord])
+  if (payload.theme !== undefined) fields.push(['theme', payload.theme])
+  if (payload.isActive !== undefined) fields.push(['is_active', payload.isActive])
+
+  if (fields.length === 0) return findPairById(id)
+
+  const setClauses = fields.map(([col], i) => `${col} = $${i + 1}`)
+  const params = [...fields.map(([, val]) => val), id]
+
+  const rows = await query<WordPairRow>(
+    `UPDATE word_pairs SET ${setClauses.join(', ')} WHERE id = $${fields.length + 1} RETURNING *`,
+    params
+  )
+  return rows.length > 0 ? mapRow(rows[0]) : null
+}
+
+export async function deactivatePair(id: string): Promise<boolean> {
+  const rows = await query<{ id: string }>(
+    'UPDATE word_pairs SET is_active = FALSE WHERE id = $1 RETURNING id',
+    [id]
+  )
+  return rows.length > 0
+}

--- a/backend/src/models/wordPair.ts
+++ b/backend/src/models/wordPair.ts
@@ -101,7 +101,9 @@ export async function createPair(payload: CreateWordPairPayload): Promise<WordPa
      RETURNING *`,
     [payload.theme, payload.civilWord, payload.impostorWord]
   )
-  return mapRow(rows[0])
+  const row = rows[0]
+  if (!row) throw new Error('INSERT word_pairs did not return a row')
+  return mapRow(row)
 }
 
 export async function updatePair(

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "lib": ["ES2022"],
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": "..",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -18,6 +18,6 @@
       "@shared/*": ["../shared/*"]
     }
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "../shared/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": false,
+    "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@shared/*": ["../shared/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Closes #32

## Ce qui a été fait

- `backend/src/models/wordPair.ts` — couche d'accès DB sans ORM, requêtes paramétrées uniquement

### Fonctions exportées

| Fonction | SQL | Retour |
|---|---|---|
| `findRandomPairByTheme(theme)` | `ORDER BY RANDOM() LIMIT 1` sur paires actives | `WordPairSelection \| null` |
| `findAllPairs(filters)` | `COUNT(*)` séparé + `LIMIT`/`OFFSET`, filtres dynamiques | `{ rows: WordPair[], total: number }` |
| `findPairById(id)` | `WHERE id = $1` | `WordPair \| null` |
| `createPair(payload)` | `INSERT ... RETURNING *` | `WordPair` |
| `updatePair(id, payload)` | SET partiel via tableau `[col, val]` | `WordPair \| null` |
| `deactivatePair(id)` | `SET is_active = FALSE RETURNING id` | `boolean` |

### Type interne `WordPairRow`

Interface privée (snake_case, `Date` pour les timestamps) → `mapRow()` convertit en `WordPair` partagé (camelCase, `.toISOString()`).

## Points notables

- `COUNT(*)` PostgreSQL retourne `string` côté JS → `parseInt(..., 10)` obligatoire
- `updatePair` utilise un tableau `[col, val][]` pour éviter la désynchronisation des index de paramètres `$N`
- `deactivatePair` : soft delete via `is_active = FALSE`, retourne `false` si l'id est introuvable
- `ORDER BY RANDOM()` : acceptable au volume attendu (commentaire inline)

## Dépendances aval

- TASK-04 (#33) — service wordService (utilise toutes ces fonctions)