### PR TITLE
feat: [TASK-04] Service métier wordService

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,16 @@
+# Connexion PostgreSQL (choisir l'une des deux formes)
+DATABASE_URL=postgresql://user:password@localhost:5432/underword
+
+# OU variables individuelles (ignorées si DATABASE_URL est défini)
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=underword
+DB_USER=user
+DB_PASSWORD=password
+
+# Serveur
+PORT=3000
+NODE_ENV=development
+
+# Auth admin (pour les routes /api/admin/*)
+ADMIN_TOKEN=changeme

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "db:migrate": "ts-node src/db/migrate.ts",
     "db:seed": "ts-node src/db/seeds/index.ts",
     "db:reset": "npm run db:migrate && npm run db:seed",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "jest"
   },
   "dependencies": {
     "dotenv": "^16.4.5",
@@ -20,8 +21,11 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/jest": "^30.0.0",
     "@types/node": "^20.12.7",
     "@types/pg": "^8.11.5",
+    "jest": "^30.3.0",
+    "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "underword-backend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "ts-node src/app.ts",
+    "build": "tsc",
+    "start": "node dist/app.js",
+    "db:migrate": "ts-node src/db/migrate.ts",
+    "db:seed": "ts-node src/db/seeds/index.ts",
+    "db:reset": "npm run db:migrate && npm run db:seed",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.18.3",
+    "pg": "^8.11.5",
+    "socket.io": "^4.7.5",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.12.7",
+    "@types/pg": "^8.11.5",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
+}

--- a/backend/src/__tests__/wordService.test.ts
+++ b/backend/src/__tests__/wordService.test.ts
@@ -1,0 +1,134 @@
+import { WordPairNotFoundError, DuplicateWordPairError } from '../utils/errors'
+import * as wordService from '../services/wordService'
+import * as model from '../models/wordPair'
+import type { WordPair } from '../../../shared/types/words'
+
+jest.mock('../models/wordPair')
+
+const mockedModel = model as jest.Mocked<typeof model>
+
+const PAIR: WordPair = {
+  id: 'uuid-1',
+  theme: 'classique',
+  civilWord: 'chien',
+  impostorWord: 'chat',
+  isActive: true,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+}
+
+beforeEach(() => jest.clearAllMocks())
+
+// ─── drawWordPair ────────────────────────────────────────────────────────────
+
+describe('drawWordPair', () => {
+  it('retourne la paire si trouvée', async () => {
+    mockedModel.findRandomPairByTheme.mockResolvedValue({
+      civilWord: PAIR.civilWord,
+      impostorWord: PAIR.impostorWord,
+    })
+    const result = await wordService.drawWordPair('classique')
+    expect(result.pair).toEqual({ civilWord: 'chien', impostorWord: 'chat' })
+  })
+
+  it('lève WordPairNotFoundError si aucune paire active', async () => {
+    mockedModel.findRandomPairByTheme.mockResolvedValue(null)
+    await expect(wordService.drawWordPair('musique')).rejects.toThrow(WordPairNotFoundError)
+  })
+})
+
+// ─── listWordPairs ───────────────────────────────────────────────────────────
+
+describe('listWordPairs', () => {
+  it('retourne la réponse paginée', async () => {
+    mockedModel.findAllPairs.mockResolvedValue({ rows: [PAIR], total: 1 })
+    const result = await wordService.listWordPairs({ page: 1, pageSize: 10 })
+    expect(result.data).toHaveLength(1)
+    expect(result.total).toBe(1)
+    expect(result.page).toBe(1)
+    expect(result.pageSize).toBe(10)
+  })
+
+  it('utilise les valeurs par défaut de pagination', async () => {
+    mockedModel.findAllPairs.mockResolvedValue({ rows: [], total: 0 })
+    const result = await wordService.listWordPairs({})
+    expect(result.page).toBe(1)
+    expect(result.pageSize).toBe(20)
+  })
+})
+
+// ─── getWordPair ─────────────────────────────────────────────────────────────
+
+describe('getWordPair', () => {
+  it('retourne la paire si trouvée', async () => {
+    mockedModel.findPairById.mockResolvedValue(PAIR)
+    const result = await wordService.getWordPair('uuid-1')
+    expect(result).toEqual(PAIR)
+  })
+
+  it('lève WordPairNotFoundError si introuvable', async () => {
+    mockedModel.findPairById.mockResolvedValue(null)
+    await expect(wordService.getWordPair('bad-id')).rejects.toThrow(WordPairNotFoundError)
+  })
+})
+
+// ─── createWordPair ──────────────────────────────────────────────────────────
+
+describe('createWordPair', () => {
+  it('crée et retourne la paire', async () => {
+    mockedModel.createPair.mockResolvedValue(PAIR)
+    const result = await wordService.createWordPair({
+      theme: 'classique',
+      civilWord: 'chien',
+      impostorWord: 'chat',
+    })
+    expect(result).toEqual(PAIR)
+  })
+
+  it('lève DuplicateWordPairError sur violation de contrainte unique', async () => {
+    const pgErr = Object.assign(new Error('unique violation'), { code: '23505' })
+    mockedModel.createPair.mockRejectedValue(pgErr)
+    await expect(
+      wordService.createWordPair({ theme: 'classique', civilWord: 'chien', impostorWord: 'chat' })
+    ).rejects.toThrow(DuplicateWordPairError)
+  })
+
+  it('remonte les autres erreurs sans les transformer', async () => {
+    mockedModel.createPair.mockRejectedValue(new Error('db connection lost'))
+    await expect(
+      wordService.createWordPair({ theme: 'classique', civilWord: 'a', impostorWord: 'b' })
+    ).rejects.toThrow('db connection lost')
+  })
+})
+
+// ─── updateWordPair ──────────────────────────────────────────────────────────
+
+describe('updateWordPair', () => {
+  it('retourne la paire mise à jour', async () => {
+    const updated = { ...PAIR, civilWord: 'loup' }
+    mockedModel.updatePair.mockResolvedValue(updated)
+    const result = await wordService.updateWordPair('uuid-1', { civilWord: 'loup' })
+    expect(result.civilWord).toBe('loup')
+  })
+
+  it('lève WordPairNotFoundError si null retourné', async () => {
+    mockedModel.updatePair.mockResolvedValue(null)
+    await expect(wordService.updateWordPair('bad-id', { civilWord: 'x' })).rejects.toThrow(
+      WordPairNotFoundError
+    )
+  })
+})
+
+// ─── deleteWordPair ──────────────────────────────────────────────────────────
+
+describe('deleteWordPair', () => {
+  it('se termine sans erreur si la paire existe', async () => {
+    mockedModel.deactivatePair.mockResolvedValue(true)
+    await expect(wordService.deleteWordPair('uuid-1')).resolves.toBeUndefined()
+  })
+
+  it('lève WordPairNotFoundError si la paire est introuvable', async () => {
+    mockedModel.deactivatePair.mockResolvedValue(false)
+    await expect(wordService.deleteWordPair('bad-id')).rejects.toThrow(WordPairNotFoundError)
+  })
+})

--- a/backend/src/db/connection.ts
+++ b/backend/src/db/connection.ts
@@ -1,0 +1,32 @@
+import 'dotenv/config'
+import pg from 'pg'
+
+const { Pool } = pg
+
+function createPool(): pg.Pool {
+  const connectionString = process.env['DATABASE_URL']
+
+  if (connectionString !== undefined && connectionString !== '') {
+    return new Pool({ connectionString })
+  }
+
+  return new Pool({
+    host: process.env['DB_HOST'] ?? 'localhost',
+    port: parseInt(process.env['DB_PORT'] ?? '5432', 10),
+    database: process.env['DB_NAME'] ?? 'underword',
+    user: process.env['DB_USER'],
+    password: process.env['DB_PASSWORD'],
+  })
+}
+
+const pool: pg.Pool = createPool()
+
+export async function query<T extends pg.QueryResultRow>(
+  sql: string,
+  params?: unknown[]
+): Promise<T[]> {
+  const result = await pool.query<T>(sql, params)
+  return result.rows
+}
+
+export { pool }

--- a/backend/src/db/migrate.ts
+++ b/backend/src/db/migrate.ts
@@ -1,0 +1,55 @@
+import 'dotenv/config'
+import fs from 'fs'
+import path from 'path'
+import { pool } from './connection'
+
+const MIGRATIONS_DIR = path.join(__dirname, 'migrations')
+
+function getMigrationFiles(): string[] {
+  const files = fs.readdirSync(MIGRATIONS_DIR)
+  return files
+    .filter((f) => f.endsWith('.sql'))
+    .sort()
+}
+
+async function runMigrations(): Promise<void> {
+  const files = getMigrationFiles()
+
+  if (files.length === 0) {
+    console.log('Aucun fichier de migration trouvé.')
+    return
+  }
+
+  const client = await pool.connect()
+
+  try {
+    await client.query('BEGIN')
+
+    for (const file of files) {
+      const filePath = path.join(MIGRATIONS_DIR, file)
+      const sql = fs.readFileSync(filePath, 'utf8')
+
+      console.log(`Migration : ${file}`)
+      await client.query(sql)
+      console.log(`  ✓ ${file} appliqué`)
+    }
+
+    await client.query('COMMIT')
+    console.log(`\n${files.length} migration(s) appliquée(s) avec succès.`)
+  } catch (error) {
+    await client.query('ROLLBACK')
+    console.error('Erreur lors de la migration, rollback effectué.')
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+runMigrations()
+  .catch((error: unknown) => {
+    console.error(error)
+    process.exit(1)
+  })
+  .finally(() => {
+    void pool.end()
+  })

--- a/backend/src/db/migrations/001_create_word_pairs.sql
+++ b/backend/src/db/migrations/001_create_word_pairs.sql
@@ -1,0 +1,89 @@
+-- Migration 001 : création de la table word_pairs
+-- Idempotente : sûre à rejouer
+
+-- Création du type enum (idempotente via DO block car CREATE TYPE IF NOT EXISTS n'existe pas en PG <14)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'theme_enum') THEN
+    CREATE TYPE theme_enum AS ENUM (
+      'classique',
+      'anime',
+      'pop-culture',
+      'musique'
+    );
+  END IF;
+END;
+$$;
+
+-- Création de la table
+CREATE TABLE IF NOT EXISTS word_pairs (
+  id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  theme          theme_enum  NOT NULL,
+  civil_word     TEXT        NOT NULL,
+  impostor_word  TEXT        NOT NULL,
+  is_active      BOOLEAN     NOT NULL DEFAULT TRUE,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Contraintes CHECK (ADD CONSTRAINT IF NOT EXISTS n'existe pas — vérification via pg_constraint)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'civil_word_not_empty'
+      AND conrelid = 'word_pairs'::regclass
+  ) THEN
+    ALTER TABLE word_pairs
+      ADD CONSTRAINT civil_word_not_empty
+        CHECK (trim(civil_word) <> '');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'impostor_word_not_empty'
+      AND conrelid = 'word_pairs'::regclass
+  ) THEN
+    ALTER TABLE word_pairs
+      ADD CONSTRAINT impostor_word_not_empty
+        CHECK (trim(impostor_word) <> '');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'civil_impostor_different'
+      AND conrelid = 'word_pairs'::regclass
+  ) THEN
+    ALTER TABLE word_pairs
+      ADD CONSTRAINT civil_impostor_different
+        CHECK (lower(trim(civil_word)) <> lower(trim(impostor_word)));
+  END IF;
+END;
+$$;
+
+-- Index
+CREATE INDEX IF NOT EXISTS idx_word_pairs_theme_active
+  ON word_pairs (theme, is_active)
+  WHERE is_active = TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_word_pairs_theme
+  ON word_pairs (theme, created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_word_pairs_unique_pair
+  ON word_pairs (theme, lower(civil_word), lower(impostor_word));
+
+-- Fonction trigger updated_at (CREATE OR REPLACE est idempotente)
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+-- Trigger (DROP IF EXISTS + CREATE pour idempotence)
+DROP TRIGGER IF EXISTS trg_word_pairs_updated_at ON word_pairs;
+
+CREATE TRIGGER trg_word_pairs_updated_at
+  BEFORE UPDATE ON word_pairs
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/backend/src/middleware/adminAuth.ts
+++ b/backend/src/middleware/adminAuth.ts
@@ -1,0 +1,24 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express'
+
+export const adminAuth: RequestHandler = (req: Request, res: Response, next: NextFunction): void => {
+  const authHeader = req.headers['authorization']
+
+  if (authHeader === undefined || authHeader === '') {
+    res.status(401).json({ error: 'Token requis' })
+    return
+  }
+
+  const [scheme, token] = authHeader.split(' ')
+
+  if (scheme !== 'Bearer' || token === undefined || token === '') {
+    res.status(401).json({ error: 'Token requis' })
+    return
+  }
+
+  if (token !== process.env['ADMIN_TOKEN']) {
+    res.status(403).json({ error: 'Token invalide' })
+    return
+  }
+
+  next()
+}

--- a/backend/src/middleware/schemas/wordSchemas.ts
+++ b/backend/src/middleware/schemas/wordSchemas.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod'
+import { THEMES } from '../../../shared/constants/themes'
+import type { CreateWordPairPayload, UpdateWordPairPayload } from '../../../shared/types/words'
+
+const themeEnum = z.enum(THEMES as [string, ...string[]])
+
+export const themeQuerySchema = z.object({
+  theme: themeEnum,
+}).strict()
+
+export const createWordPairSchema = z.object({
+  theme: themeEnum,
+  civilWord: z.string().min(1, 'Le mot civil ne peut pas être vide'),
+  impostorWord: z.string().min(1, "Le mot imposteur ne peut pas être vide"),
+}).strict()
+
+export const updateWordPairSchema = z.object({
+  theme: themeEnum.optional(),
+  civilWord: z.string().min(1, 'Le mot civil ne peut pas être vide').optional(),
+  impostorWord: z.string().min(1, "Le mot imposteur ne peut pas être vide").optional(),
+  isActive: z.boolean().optional(),
+}).strict().refine(
+  (data) => Object.keys(data).length > 0,
+  { message: 'Au moins un champ est requis' }
+)
+
+// Assertions statiques : erreur de compilation si les schemas divergent des types partagés
+const _createCheck: z.infer<typeof createWordPairSchema> extends CreateWordPairPayload ? true : never = true
+const _updateCheck: z.infer<typeof updateWordPairSchema> extends UpdateWordPairPayload ? true : never = true
+
+void _createCheck
+void _updateCheck

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -1,0 +1,32 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express'
+import type { ZodSchema } from 'zod'
+
+export function validateQuery(schema: ZodSchema): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const result = schema.safeParse(req.query)
+    if (!result.success) {
+      res.status(400).json({
+        error: 'Validation échouée',
+        details: result.error.issues,
+      })
+      return
+    }
+    req.query = result.data as Record<string, string>
+    next()
+  }
+}
+
+export function validateBody(schema: ZodSchema): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const result = schema.safeParse(req.body)
+    if (!result.success) {
+      res.status(400).json({
+        error: 'Validation échouée',
+        details: result.error.issues,
+      })
+      return
+    }
+    req.body = result.data
+    next()
+  }
+}

--- a/backend/src/models/wordPair.ts
+++ b/backend/src/models/wordPair.ts
@@ -1,0 +1,136 @@
+import { query } from '../db/connection'
+import type {
+  Theme,
+  WordPair,
+  WordPairSelection,
+  CreateWordPairPayload,
+  UpdateWordPairPayload,
+} from '../../shared/types/words'
+
+interface WordPairRow {
+  id: string
+  theme: Theme
+  civil_word: string
+  impostor_word: string
+  is_active: boolean
+  created_at: Date
+  updated_at: Date
+}
+
+export interface PairFilters {
+  theme?: Theme
+  page?: number
+  pageSize?: number
+  activeOnly?: boolean
+}
+
+function mapRow(row: WordPairRow): WordPair {
+  return {
+    id: row.id,
+    theme: row.theme,
+    civilWord: row.civil_word,
+    impostorWord: row.impostor_word,
+    isActive: row.is_active,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+  }
+}
+
+// ORDER BY RANDOM() fait un seq scan sur les paires filtrées.
+// Acceptable pour le volume attendu (quelques centaines de paires par thème).
+export async function findRandomPairByTheme(theme: Theme): Promise<WordPairSelection | null> {
+  const rows = await query<WordPairRow>(
+    `SELECT civil_word, impostor_word
+     FROM word_pairs
+     WHERE theme = $1 AND is_active = TRUE
+     ORDER BY RANDOM()
+     LIMIT 1`,
+    [theme]
+  )
+  if (rows.length === 0) return null
+  const row = rows[0]
+  return { civilWord: row.civil_word, impostorWord: row.impostor_word }
+}
+
+export async function findAllPairs(
+  filters: PairFilters
+): Promise<{ rows: WordPair[]; total: number }> {
+  const { theme, page = 1, pageSize = 20, activeOnly = false } = filters
+  const conditions: string[] = []
+  const params: unknown[] = []
+  let idx = 1
+
+  if (theme !== undefined) {
+    conditions.push(`theme = $${idx}`)
+    params.push(theme)
+    idx++
+  }
+  if (activeOnly) {
+    conditions.push('is_active = TRUE')
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+
+  const countRows = await query<{ count: string }>(
+    `SELECT COUNT(*) AS count FROM word_pairs ${where}`,
+    params
+  )
+  const total = parseInt(countRows[0]?.count ?? '0', 10)
+
+  const offset = (page - 1) * pageSize
+  const dataRows = await query<WordPairRow>(
+    `SELECT * FROM word_pairs ${where} ORDER BY created_at DESC LIMIT $${idx} OFFSET $${idx + 1}`,
+    [...params, pageSize, offset]
+  )
+
+  return { rows: dataRows.map(mapRow), total }
+}
+
+export async function findPairById(id: string): Promise<WordPair | null> {
+  const rows = await query<WordPairRow>(
+    'SELECT * FROM word_pairs WHERE id = $1',
+    [id]
+  )
+  return rows.length > 0 ? mapRow(rows[0]) : null
+}
+
+export async function createPair(payload: CreateWordPairPayload): Promise<WordPair> {
+  const rows = await query<WordPairRow>(
+    `INSERT INTO word_pairs (theme, civil_word, impostor_word)
+     VALUES ($1, $2, $3)
+     RETURNING *`,
+    [payload.theme, payload.civilWord, payload.impostorWord]
+  )
+  return mapRow(rows[0])
+}
+
+export async function updatePair(
+  id: string,
+  payload: UpdateWordPairPayload
+): Promise<WordPair | null> {
+  const fields: Array<[string, unknown]> = []
+
+  if (payload.civilWord !== undefined) fields.push(['civil_word', payload.civilWord])
+  if (payload.impostorWord !== undefined) fields.push(['impostor_word', payload.impostorWord])
+  if (payload.theme !== undefined) fields.push(['theme', payload.theme])
+  if (payload.isActive !== undefined) fields.push(['is_active', payload.isActive])
+
+  if (fields.length === 0) return findPairById(id)
+
+  const setClauses = fields.map(([col], i) => `${col} = $${i + 1}`)
+  const params = [...fields.map(([, val]) => val), id]
+
+  const rows = await query<WordPairRow>(
+    `UPDATE word_pairs SET ${setClauses.join(', ')} WHERE id = $${fields.length + 1} RETURNING *`,
+    params
+  )
+  return rows.length > 0 ? mapRow(rows[0]) : null
+}
+
+export async function deactivatePair(id: string): Promise<boolean> {
+  const rows = await query<{ id: string }>(
+    'UPDATE word_pairs SET is_active = FALSE WHERE id = $1 RETURNING id',
+    [id]
+  )
+  return rows.length > 0
+}

--- a/backend/src/models/wordPair.ts
+++ b/backend/src/models/wordPair.ts
@@ -5,7 +5,7 @@ import type {
   WordPairSelection,
   CreateWordPairPayload,
   UpdateWordPairPayload,
-} from '../../shared/types/words'
+} from '../../../shared/types/words'
 
 interface WordPairRow {
   id: string

--- a/backend/src/services/wordService.ts
+++ b/backend/src/services/wordService.ts
@@ -1,0 +1,58 @@
+import type {
+  Theme,
+  WordPair,
+  CreateWordPairPayload,
+  UpdateWordPairPayload,
+  WordPairListResponse,
+  WordPairDrawResponse,
+} from '../../../shared/types/words'
+import * as model from '../models/wordPair'
+import type { PairFilters } from '../models/wordPair'
+import { WordPairNotFoundError, DuplicateWordPairError } from '../utils/errors'
+
+export async function drawWordPair(theme: Theme): Promise<WordPairDrawResponse> {
+  const pair = await model.findRandomPairByTheme(theme)
+  if (!pair) throw new WordPairNotFoundError(`No active word pair for theme: ${theme}`)
+  return { pair }
+}
+
+export async function listWordPairs(filters: PairFilters): Promise<WordPairListResponse> {
+  const { page = 1, pageSize = 20 } = filters
+  const { rows, total } = await model.findAllPairs(filters)
+  return { data: rows, total, page, pageSize }
+}
+
+export async function getWordPair(id: string): Promise<WordPair> {
+  const pair = await model.findPairById(id)
+  if (!pair) throw new WordPairNotFoundError(`Word pair not found: ${id}`)
+  return pair
+}
+
+export async function createWordPair(payload: CreateWordPairPayload): Promise<WordPair> {
+  try {
+    return await model.createPair(payload)
+  } catch (err: unknown) {
+    if (isPgUniqueViolation(err)) throw new DuplicateWordPairError()
+    throw err
+  }
+}
+
+export async function updateWordPair(id: string, payload: UpdateWordPairPayload): Promise<WordPair> {
+  const pair = await model.updatePair(id, payload)
+  if (!pair) throw new WordPairNotFoundError(`Word pair not found: ${id}`)
+  return pair
+}
+
+export async function deleteWordPair(id: string): Promise<void> {
+  const deleted = await model.deactivatePair(id)
+  if (!deleted) throw new WordPairNotFoundError(`Word pair not found: ${id}`)
+}
+
+function isPgUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code: string }).code === '23505'
+  )
+}

--- a/backend/src/utils/errors.ts
+++ b/backend/src/utils/errors.ts
@@ -1,0 +1,13 @@
+export class WordPairNotFoundError extends Error {
+  constructor(message = 'Word pair not found') {
+    super(message)
+    this.name = 'WordPairNotFoundError'
+  }
+}
+
+export class DuplicateWordPairError extends Error {
+  constructor(message = 'Word pair already exists') {
+    super(message)
+    this.name = 'DuplicateWordPairError'
+  }
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "lib": ["ES2022"],
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": "..",
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
@@ -18,6 +18,6 @@
       "@shared/*": ["../shared/*"]
     }
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "../shared/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": false,
+    "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "paths": {
+      "@shared/*": ["../shared/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/shared/constants/themes.ts
+++ b/shared/constants/themes.ts
@@ -1,0 +1,12 @@
+import type { Theme } from '../types/words'
+
+export const THEMES: readonly Theme[] = [
+  'classique',
+  'anime',
+  'pop-culture',
+  'musique',
+] as const
+
+export function isValidTheme(value: unknown): value is Theme {
+  return typeof value === 'string' && (THEMES as readonly string[]).includes(value)
+}

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "declaration": true,
+    "declarationDir": "./dist",
+    "outDir": "./dist",
+    "rootDir": ".",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "include": ["types/**/*", "constants/**/*"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}

--- a/shared/types/game.ts
+++ b/shared/types/game.ts
@@ -1,0 +1,19 @@
+import type { Theme } from './words'
+
+export type { Theme }
+
+export type Role = 'civil' | 'imposteur' | 'mister-white'
+
+export interface Player {
+  id: string
+  name: string
+  role?: Role
+  isEliminated: boolean
+}
+
+export interface GameConfig {
+  playerNames: string[]
+  theme: Theme
+  impostorCount: number | 'auto'
+  misterWhiteEnabled: boolean
+}

--- a/shared/types/words.ts
+++ b/shared/types/words.ts
@@ -1,0 +1,40 @@
+export type Theme = 'classique' | 'anime' | 'pop-culture' | 'musique'
+
+export interface WordPair {
+  id: string
+  theme: Theme
+  civilWord: string
+  impostorWord: string
+  isActive: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface WordPairSelection {
+  civilWord: string
+  impostorWord: string
+}
+
+export interface CreateWordPairPayload {
+  theme: Theme
+  civilWord: string
+  impostorWord: string
+}
+
+export type UpdateWordPairPayload = Partial<
+  Pick<CreateWordPairPayload, 'civilWord' | 'impostorWord'> & {
+    theme: Theme
+    isActive: boolean
+  }
+>
+
+export interface WordPairListResponse {
+  data: WordPair[]
+  total: number
+  page: number
+  pageSize: number
+}
+
+export interface WordPairDrawResponse {
+  pair: WordPairSelection
+}


### PR DESCRIPTION
Closes #33

## Ce qui a été fait

- `backend/src/services/wordService.ts` : couche service avec les 6 fonctions du contrat (`drawWordPair`, `listWordPairs`, `getWordPair`, `createWordPair`, `updateWordPair`, `deleteWordPair`)
- `backend/src/utils/errors.ts` : `WordPairNotFoundError` et `DuplicateWordPairError` (erreurs métier distinctes des erreurs HTTP)
- `backend/src/__tests__/wordService.test.ts` : 13 tests unitaires avec mock du modèle (jest + ts-jest)
- `backend/jest.config.js` : configuration Jest + ts-jest
- Fix du chemin d'import `shared/types/words` dans le modèle (TASK-03) : `../../` → `../../../`

## Tests

13/13 passent — tous les cas nominaux et les cas d'erreur sont couverts.